### PR TITLE
- Added options 'detachToWidth' and 'detachToHeight' to specify fixed…

### DIFF
--- a/Code/docker.js
+++ b/Code/docker.js
@@ -80,7 +80,9 @@ function wcDocker(container, options) {
     allowCollapse: true,
     responseRate: 10,
     edgeAnchorSize: 50,
-    panelAnchorSize: '15%'
+    panelAnchorSize: '15%',
+    detachToWidth: 600,
+    detachToHeight: 400
   };
 
   this._options = {};

--- a/Code/docker.jsdoc
+++ b/Code/docker.jsdoc
@@ -11,6 +11,8 @@
  * @property {Number} [responseRate=10] - This determines how often updates are performed (in milliseconds).
  * @property {Number|String} [edgeAnchorSize=50] - Determines the size of the anchor points when docking a panel to the outer edge of the window.
  * @property {Number|String} [panelAnchorSize='15%'] - Determines the size of the anchor points when docking a panel along the side of another panel.
+ * @property {Number|String} [detachToWidth=600] - Determines the new width when a panel is detached (0 = Don't change). Can be a pixel value, or a string with a 'px' or '%' suffix.
+ * @property {Number|String} [detachToHeight=400] - Determines the new height when a panel is detached (0 = Don't change).  Can be a pixel value, or a string with a 'px' or '%' suffix.
  */
 
 /**

--- a/Code/ghost.js
+++ b/Code/ghost.js
@@ -89,6 +89,17 @@ wcGhost.prototype = {
         return;
       }
 
+      if(this._docker._draggingFrame && this._docker._draggingFrame.$container) {
+        var r = {
+          w: this._docker._draggingFrame.$container.width(),
+          h: this._docker._draggingFrame.$container.height()
+        };
+        var detachToWidth = this._docker._draggingFrame._panelList[0]._options.detachToWidth || this._docker._options.detachToWidth;
+        var detachToHeight = this._docker._draggingFrame._panelList[0]._options.detachToHeight || this._docker._options.detachToHeight;
+        this._rect.w = this._docker.__stringToPixel( detachToWidth || this._rect.w, r.w);
+        this._rect.h = this._docker.__stringToPixel( detachToHeight || this._rect.h, r.h);
+      }
+
       this._anchor = null;
       this.$ghost.show();
       this.$ghost.stop().animate({

--- a/Code/panel.js
+++ b/Code/panel.js
@@ -19,6 +19,8 @@ function wcPanel(type, options) {
    * @property {String} [icon] - A CSS classname that represents the icon that should display on this panel's tab widget.
    * @property {String} [faicon] - An icon name using the [Font-Awesome]{@link http://fortawesome.github.io/Font-Awesome/} library.
    * @property {String|Boolean} [title] - A custom title to display for this panel, if false, title bar will not be shown.
+   * @property {Number|String} [detachToWidth=600] - Determines the new width when the panel is detached (0 = Don't change). Can be a pixel value, or a string with a 'px' or '%' suffix.
+   * @property {Number|String} [detachToHeight=400] - Determines the new height when the panel is detached (0 = Don't change).  Can be a pixel value, or a string with a 'px' or '%' suffix.
    */
 
   /**


### PR DESCRIPTION
… width height for a panel followed by the user detaches it. A value 0 (default) means the original width/height of the panel.

When the user detaches one of the panels and if this is espacially a full width or full height panel, keeping the same dimensions after having it detached makes placing/resizing it a little bit harder due to its overflowed edge(s). This change adds a custom width and height option to predefine the size of the panels (possibly a smaller size) when they are detached. A value 0 means "use the original size" which will get the same behaviour before this change.