### PR TITLE
Fix Iframe load issue with jQuery - 3.2.1

### DIFF
--- a/Code/iframe.js
+++ b/Code/iframe.js
@@ -79,7 +79,7 @@ define([
             this.$iFrame.hover(this.__onHoverEnter.bind(this), this.__onHoverExit.bind(this));
 
             var self = this;
-            this.$iFrame.load(function () {
+            this.$iFrame.on('load', function () {
                 for (var i = 0; i < self._onLoadFuncs.length; ++i) {
                     self._onLoadFuncs[i]();
                 }
@@ -111,7 +111,7 @@ define([
             this.$iFrame.hover(this.__onHoverEnter.bind(this), this.__onHoverExit.bind(this));
 
             var self = this;
-            this.$iFrame.load(function () {
+            this.$iFrame.on('load', function () {
                 for (var i = 0; i < self._onLoadFuncs.length; ++i) {
                     self._onLoadFuncs[i]();
                 }
@@ -141,7 +141,7 @@ define([
             this.$iFrame.hover(this.__onHoverEnter.bind(this), this.__onHoverExit.bind(this));
 
             var self = this;
-            this.$iFrame.load(function () {
+            this.$iFrame.on('load', function () {
                 for (var i = 0; i < self._onLoadFuncs.length; ++i) {
                     self._onLoadFuncs[i]();
                 }


### PR DESCRIPTION
Replace depreciated load() method with the one supported with latest jQuery version 3.2.1

I got this issue when I used wcDocker with latest jQuery. it throws following error when an Iframe is loaded with url:
"Uncaught TypeError: url.indexOf is not a function” 

Replaced `this.$iFrame.load(function () {});` with `this.$iFrame.on('load', function () {});`
