### PR TITLE
Replaced jQuery old shorthand event methods with the new methods

### DIFF
--- a/Code/ThemeBuilder.js
+++ b/Code/ThemeBuilder.js
@@ -143,7 +143,7 @@ define([
 
                 var $pull = $('<button style="width:100%;" title="Pull attributes from the currently active theme.">Pull</button>');
                 self._panel.layout().addItem($pull, 0, row).stretch('25%', '');
-                $pull.click(function () {
+                $pull.on('click',function () {
                     self._panel.startLoading();
                     setTimeout(function() {
                         var isMobile = $('body').hasClass('wcMobile');
@@ -155,7 +155,7 @@ define([
 
                 var $apply = $('<button class="wcCustomThemeApplied" style="width:100%;" title="Apply these attributes to the theme.">Apply</button>');
                 self._panel.layout().addItem($apply, 1, row).stretch('25%', '');
-                $apply.click(function () {
+                $apply.on('click',function () {
                     var themeData = self.build();
                     self.apply(themeData);
                     $apply.addClass('wcButtonActive');
@@ -168,7 +168,7 @@ define([
 
                 var $mobile = $('<button style="width:100%;" title="Toggle mobile theme overrides.">Mobile</button>');
                 self._panel.layout().addItem($mobile, 2, row).stretch('25%', '');
-                $mobile.click(function () {
+                $mobile.on('click',function () {
                     self._panel.startLoading();
                     setTimeout(function() {
                         self.buildControls(!showMobile);
@@ -183,7 +183,7 @@ define([
 
                 var $download = $('<button style="width:100%;" title="Download your custom theme.">Download</button>');
                 self._panel.layout().addItem($download, 3, row).stretch('25%', '');
-                $download.click(function () {
+                $download.on('click',function () {
                     var themeData = self.build();
                     var blob = new Blob([themeData], {type: "text/plain;charset=utf-8"});
                     saveAs(blob, "myTheme.css");
@@ -332,7 +332,7 @@ define([
                 $activator = this._lastCheckbox;
             }
 
-            $activator.change(function () {
+            $activator.on('change',function () {
                 control[disabledProp] = !this.checked;
                 $control.spectrum(this.checked ? 'enable' : 'disable');
                 self.onChanged();
@@ -362,7 +362,7 @@ define([
             $control = $('<input class="wcAttributeControl" title="' + control.info + '" type="text"/>');
             layout.addItem($control, 2, row, 2).stretch('100%', '');
             $control.val(control[valueProp]);
-            $control.change(function () {
+            $control.on('change',function () {
                 control[valueProp] = $(this).val();
                 if (!showMobile && control.isMobileDisabled) {
                     control.mobileValue = control.value;
@@ -380,7 +380,7 @@ define([
                 $activator = this._lastCheckbox;
             }
 
-            $activator.change(function () {
+            $activator.on('change',function () {
                 control[disabledProp] = !this.checked;
                 $control.attr('disabled', !this.checked);
                 self.onChanged();
@@ -410,7 +410,7 @@ define([
             $control = $('<input class="wcAttributeControl" title="' + control.info + '" type="number" step="1"/>');
             layout.addItem($control, 2, row, 2).stretch('100%', '');
             $control.val(parseInt(control[valueProp]));
-            $control.change(function () {
+            $control.on('change',function () {
                 control[valueProp] = $(this).val() + 'px';
                 if (!showMobile && control.isMobileDisabled) {
                     control.mobileValue = control.value;
@@ -428,7 +428,7 @@ define([
                 $activator = this._lastCheckbox;
             }
 
-            $activator.change(function () {
+            $activator.on('change',function () {
                 control[disabledProp] = !this.checked;
                 $control.attr('disabled', !this.checked);
                 self.onChanged();
@@ -472,7 +472,7 @@ define([
                     $control.append($('<option value="' + value + '"' + (control[valueProp] === value ? ' selected' : '') + '>' + display + '</option>'));
                 }
 
-                $control.change(function () {
+                $control.on('change',function () {
                     control[valueProp] = $(this).val();
                     if (!showMobile && control.isMobileDisabled) {
                         control.mobileValue = control.value;
@@ -490,7 +490,7 @@ define([
                     $activator = this._lastCheckbox;
                 }
 
-                $activator.change(function () {
+                $activator.on('change',function () {
                     control[disabledProp] = !this.checked;
                     $control.attr('disabled', !this.checked);
                     self.onChanged();
@@ -822,7 +822,7 @@ define([
                 var $customTheme = $('#wcCustomTheme');
                 if ($customTheme.length) {
                     $('option.custom').hide();
-                    $('.themeSelector').val('default').change();
+                    $('.themeSelector').val('default').trigger('change');
                     $customTheme.remove();
                 }
             });

--- a/Code/docker.js
+++ b/Code/docker.js
@@ -1056,7 +1056,7 @@ define([
                                         target = anchor.item._parent;
                                     }
                                     var newPanel = self.addPanel(key, anchor.loc, target, self._ghost.rect());
-                                    newPanel.focus();
+                                    newPanel.trigger('focus');
                                 }
                             }
                         },
@@ -1824,7 +1824,7 @@ define([
                             var index = parseInt($panelTab.attr('id'));
                             self._draggingFrame.panel(index, true);
                             self._draggingFrameTab = $panelTab[0];
-                            $(window).focus();
+                            $(window).trigger('focus');
                         }
 
                         // If the window is able to be docked, give it a dark shadow tint and begin the movement process

--- a/Code/frame.js
+++ b/Code/frame.js
@@ -411,7 +411,7 @@ define([
                 this.$frame.addClass('wcFloating');
             }
 
-            this.$center.scroll(this.__scrolled.bind(this));
+            this.$center.on('scroll',this.__scrolled.bind(this));
         },
 
         // Updates the size of the frame.

--- a/Code/iframe.js
+++ b/Code/iframe.js
@@ -75,11 +75,14 @@ define([
             this.__updateFrame();
             this._window.location.replace(url);
 
-            this.$iFrame[0].focus();
-            this.$iFrame.hover(this.__onHoverEnter.bind(this), this.__onHoverExit.bind(this));
+            this.$iFrame[0].trigger('focus');
+            this.$iFrame.on({
+                mouseenter:this.__onHoverEnter.bind(this),
+                mouseleave:this.__onHoverExit.bind(this)
+            });
 
             var self = this;
-            this.$iFrame.load(function () {
+            this.$iFrame.on('load',function () {
                 for (var i = 0; i < self._onLoadFuncs.length; ++i) {
                     self._onLoadFuncs[i]();
                 }
@@ -107,11 +110,14 @@ define([
             this._window.document.write(html);
             this._window.document.close();
 
-            this.$iFrame[0].focus();
-            this.$iFrame.hover(this.__onHoverEnter.bind(this), this.__onHoverExit.bind(this));
+            this.$iFrame[0].trigger('focus');
+            this.$iFrame.on({
+                mouseenter:this.__onHoverEnter.bind(this),
+                mouseleave:this.__onHoverExit.bind(this)
+            });
 
             var self = this;
-            this.$iFrame.load(function () {
+            this.$iFrame.on('load',function () {
                 for (var i = 0; i < self._onLoadFuncs.length; ++i) {
                     self._onLoadFuncs[i]();
                 }
@@ -137,11 +143,14 @@ define([
 
             // Write the frame source.
             this.$iFrame[0].srcdoc = html;
-            this.$iFrame[0].focus();
-            this.$iFrame.hover(this.__onHoverEnter.bind(this), this.__onHoverExit.bind(this));
+            this.$iFrame[0].trigger('focus');
+            this.$iFrame.on({
+                mouseenter:this.__onHoverEnter.bind(this),
+                mouseleave:this.__onHoverExit.bind(this)
+            });
 
             var self = this;
-            this.$iFrame.load(function () {
+            this.$iFrame.on('load',function () {
                 for (var i = 0; i < self._onLoadFuncs.length; ++i) {
                     self._onLoadFuncs[i]();
                 }
@@ -249,7 +258,7 @@ define([
                 this._panel.on(this._boundEvents[i].event, this._boundEvents[i].handler);
             }
 
-            $(window).blur(this.__onBlur.bind(this));
+            $(window).on('blur',this.__onBlur.bind(this));
         },
 
         __clearFrame: function () {


### PR DESCRIPTION
Replaced jQuery old shorthand event methods with the new methods to make jQuery 3.x compatible as updating jQuery version breaks wcDocker. This will allow everyone using wcDocker to update jQuery